### PR TITLE
Installer changes to accomodate public ip removal

### DIFF
--- a/pkg/api/featureflags.go
+++ b/pkg/api/featureflags.go
@@ -20,4 +20,8 @@ const (
 	// Unit (MTU) on Azure virtual networks, which as of late 2021 is 3900 bytes.
 	// Otherwise cluster nodes will use the DHCP-provided MTU of 1500 bytes.
 	FeatureFlagMTU3900 = "Microsoft.RedHatOpenShift/MTU3900"
+
+	// FeatureFlagUserDefinedRouting is the feature in the subscription that is used to indicate we need to
+	// provision a private cluster without an IP address
+	FeatureFlagUserDefinedRouting = "Microsoft.RedHatOpenShift/UserDefinedRouting"
 )

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -264,7 +264,7 @@ type NetworkProfile struct {
 	ServiceCIDR            string                 `json:"serviceCidr,omitempty"`
 	SoftwareDefinedNetwork SoftwareDefinedNetwork `json:"softwareDefinedNetwork,omitempty"`
 	MTUSize                MTUSize                `json:"mtuSize,omitempty"`
-	OutboundType           OutboundType           `json:"outboundType,omitempty" mutable:"true"`
+	OutboundType           OutboundType           `json:"outboundType,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -247,6 +247,15 @@ const (
 	MTU3900 MTUSize = 3900
 )
 
+// OutboundType represents the type of routing a cluster is using
+type OutboundType string
+
+// OutboundType constants
+const (
+	OutboundTypeUserDefinedRouting OutboundType = "UserDefinedRouting"
+	OutboundTypeLoadbalancer       OutboundType = "Loadbalancer"
+)
+
 // NetworkProfile represents a network profile
 type NetworkProfile struct {
 	MissingFields
@@ -255,6 +264,7 @@ type NetworkProfile struct {
 	ServiceCIDR            string                 `json:"serviceCidr,omitempty"`
 	SoftwareDefinedNetwork SoftwareDefinedNetwork `json:"softwareDefinedNetwork,omitempty"`
 	MTUSize                MTUSize                `json:"mtuSize,omitempty"`
+	OutboundType           OutboundType           `json:"outboundType,omitempty" mutable:"true"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -4,7 +4,6 @@ package installer
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 
@@ -21,7 +20,7 @@ import (
 // applyInstallConfigCustomisations modifies the InstallConfig and creates
 // parent assets, then regenerates the InstallConfig for use for Ignition
 // generation, etc.
-func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
+func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
 	clusterID := &installconfig.ClusterID{
 		UUID:    m.clusterUUID,
 		InfraID: m.oc.Properties.InfraID,

--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -13,25 +13,30 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 func (m *manager) networkBootstrapNIC(installConfig *installconfig.InstallConfig) *arm.Resource {
+	// Private clusters without Public IPs will not have valid external load balancers
+	lbBackendAddressPool := &[]mgmtnetwork.BackendAddressPool{
+		{
+			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
+		},
+	}
+	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeLoadbalancer {
+		*lbBackendAddressPool = append(*lbBackendAddressPool, mgmtnetwork.BackendAddressPool{
+			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
+		})
+	}
 	return &arm.Resource{
 		Resource: &mgmtnetwork.Interface{
 			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
 				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
 					{
 						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
-								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
-								},
-								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
-								},
-							},
+							LoadBalancerBackendAddressPools: lbBackendAddressPool,
 							Subnet: &mgmtnetwork.Subnet{
 								ID: &m.oc.Properties.MasterProfile.SubnetID,
 							},
@@ -49,23 +54,27 @@ func (m *manager) networkBootstrapNIC(installConfig *installconfig.InstallConfig
 }
 
 func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) *arm.Resource {
+	// Private clusters without Public IPs not have valid external load balancers
+	lbBackendAddressPool := &[]mgmtnetwork.BackendAddressPool{
+		{
+			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
+		},
+		{
+			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', concat('ssh-', copyIndex()))]", m.oc.Properties.InfraID)),
+		},
+	}
+	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeLoadbalancer {
+		*lbBackendAddressPool = append(*lbBackendAddressPool, mgmtnetwork.BackendAddressPool{
+			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
+		})
+	}
 	return &arm.Resource{
 		Resource: &mgmtnetwork.Interface{
 			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
 				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
 					{
 						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
-								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
-								},
-								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
-								},
-								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', concat('ssh-', copyIndex()))]", m.oc.Properties.InfraID)),
-								},
-							},
+							LoadBalancerBackendAddressPools: lbBackendAddressPool,
 							Subnet: &mgmtnetwork.Subnet{
 								ID: &m.oc.Properties.MasterProfile.SubnetID,
 							},

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -107,8 +107,10 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 	}
 
 	SoftwareDefinedNetwork := string(api.SoftwareDefinedNetworkOpenShiftSDN)
-	if m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork != "" {
-		SoftwareDefinedNetwork = string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
+	// determine outbound type based on cluster visibility
+	outboundType := azuretypes.LoadbalancerOutboundType
+	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
+		outboundType = azuretypes.UserDefinedRoutingOutboundType
 	}
 
 	installConfig := &installconfig.InstallConfig{
@@ -182,7 +184,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 					ControlPlaneSubnet:       masterSubnetName,
 					ComputeSubnet:            workerSubnetName,
 					CloudName:                azuretypes.CloudEnvironment(m.env.Environment().Name),
-					OutboundType:             azuretypes.LoadbalancerOutboundType,
+					OutboundType:             outboundType,
 					ResourceGroupName:        resourceGroup,
 				},
 			},

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -37,7 +37,7 @@ func (m *manager) Manifests(ctx context.Context) (graph.Graph, error) {
 		steps.Action(func(ctx context.Context) error {
 			var err error
 			// Applies ARO-specific customisations to the InstallConfig
-			g, err = m.applyInstallConfigCustomisations(ctx, installConfig, image)
+			g, err = m.applyInstallConfigCustomisations(installConfig, image)
 			return err
 		}),
 		steps.Action(func(ctx context.Context) error {


### PR DESCRIPTION
Changes:
- gofmt changes:
  - ~~Removed func setupFileHook(baseDir string) func() { as it was unused~~
  - Removed Context from func (m *manager) applyInstallConfigCustomisations as it was an unused parameter
- changes to acommodate public ip removal

Changes were pulled directly from https://github.com/hawkowl/ARO-Installer/pull/5/.  Additional changes were needed for `pkg/api/openshiftcluster.go` as well.

