### PR TITLE
Use instancemeta populated resource manager endpoint

### DIFF
--- a/pkg/util/instancemetadata/prod.go
+++ b/pkg/util/instancemetadata/prod.go
@@ -49,13 +49,14 @@ func (p *prod) getServicePrincipalTokenAndClientIdFromMSI() (string, string, err
 		return "", "", err
 	}
 
-	msi_endpoint, err := url.Parse("http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01")
+	msi_endpoint, err := url.Parse("http://169.254.169.254/metadata/identity/oauth2/token")
 	if err != nil {
 		return "", "", err
 	}
 
 	msi_parameters := msi_endpoint.Query()
-	msi_parameters.Add("resource", "https://management.azure.com/")
+	msi_parameters.Add("api-version", "2018-02-01")
+	msi_parameters.Add("resource", p.instanceMetadata.environment.ResourceManagerEndpoint)
 	msi_parameters.Add("mi_res_id", fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-aks-cluster-%03d-agentpool",
 		p.SubscriptionID(),


### PR DESCRIPTION
The resource manager endpoint is dependant on the Cloud Environment, so we need to use the dynamically populated `instanceMetadata.environment.ResourceManagerEndpoint` to ensure we can authenticate in anywhere.

I have tested this by building both a 4.10 and a 4.11 Installer and creating clusters in a dedicated RP environment.