### PR TITLE
enable accelerated networking

### DIFF
--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	azuretypes "github.com/openshift/installer/pkg/types/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -71,6 +72,7 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 	return &arm.Resource{
 		Resource: &mgmtnetwork.Interface{
 			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
+				EnableAcceleratedNetworking: to.BoolPtr(installConfig.Config.ControlPlane.Platform.Azure.VMNetworkingType == string(azuretypes.VMnetworkingTypeAccelerated)),
 				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
 					{
 						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{

--- a/pkg/installer/generateconfig_test.go
+++ b/pkg/installer/generateconfig_test.go
@@ -1,0 +1,47 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/openshift/installer/pkg/types/azure"
+)
+
+func TestVMNetworkingType(t *testing.T) {
+	capabilityName := azure.AcceleratedNetworkingEnabled
+	for _, tt := range []struct {
+		name     string
+		sku      *mgmtcompute.ResourceSku
+		wantType string
+	}{
+		{
+			name: "sku with support for accelerated networking",
+			sku: &mgmtcompute.ResourceSku{
+				Capabilities: &([]mgmtcompute.ResourceSkuCapabilities{
+					{Name: &capabilityName, Value: to.StringPtr("True")},
+				}),
+			},
+			wantType: "Accelerated",
+		}, {
+			name: "sku without support for accelerated networking",
+			sku: &mgmtcompute.ResourceSku{
+				Capabilities: &([]mgmtcompute.ResourceSkuCapabilities{
+					{Name: &capabilityName, Value: to.StringPtr("False")},
+				}),
+			},
+			wantType: "Basic",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineVMNetworkingType(tt.sku)
+
+			if result != tt.wantType {
+				t.Error(result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Which issue this PR addresses:**

Fixes https://issues.redhat.com/browse/ARO-1487

**What this PR does / why we need it:**
This PR enables Accelerated Networking for VM Types that support it by checking for the capability in the vm SKU.

**Test plan for issue:**
- Added unit tests for determining network type.
- Created a cluster and verified Azure Portal shows Accelerated Networking is enabled for masters/workers.  Did NOT test this with vmsizes that don't support accelerated networking as there are not any available in the dev sub.
- Upgraded a cluster from from 4.11.16 -> 4.11.21 to validate network connectivity to Gateway.
- Created an image stream and deployed an app using the image stream.
