### PR TITLE
Updating go-toolset version to 1.18.4 from 1.18.4-8

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,6 +1,6 @@
 # Uses a multi-stage container build to build ARO-Installer.
 ARG REGISTRY=registry.access.redhat.com
-FROM ${REGISTRY}/ubi8/go-toolset:1.18.4-8 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.18.4 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/openshift/ARO-Installer


### PR DESCRIPTION
Which issue this PR addresses:
Fixes ARO-Installer go-toolset version

What this PR does / why we need it:
Updating go-toolset version from 1.18.4-8 to 1.18.4. As 1.18.4-8 does not exist on our ACR

Test plan for issue:
N/A

Is there any documentation that needs to be updated for this PR?
N/A