### PR TITLE
[release-4.10] ARO-1476: Allow user to set NetworkType

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -106,7 +106,12 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		masterZones = []string{""}
 	}
 
+	// Set the Network Type to OpenshiftSDN
 	SoftwareDefinedNetwork := string(api.SoftwareDefinedNetworkOpenShiftSDN)
+	if string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork) != "" {
+		SoftwareDefinedNetwork = string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
+	}
+
 	// determine outbound type based on cluster visibility
 	outboundType := azuretypes.LoadbalancerOutboundType
 	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {


### PR DESCRIPTION
[ARO-1476](https://issues.redhat.com//browse/ARO-1476)

This change allows the user to pass in the NetworkType for 4.10. We found this while working on setting the default to OVNKubernetes in 4.11.

Related #16 