### PR TITLE
remove udr feature flag

### DIFF
--- a/pkg/api/featureflags.go
+++ b/pkg/api/featureflags.go
@@ -20,8 +20,4 @@ const (
 	// Unit (MTU) on Azure virtual networks, which as of late 2021 is 3900 bytes.
 	// Otherwise cluster nodes will use the DHCP-provided MTU of 1500 bytes.
 	FeatureFlagMTU3900 = "Microsoft.RedHatOpenShift/MTU3900"
-
-	// FeatureFlagUserDefinedRouting is the feature in the subscription that is used to indicate we need to
-	// provision a private cluster without an IP address
-	FeatureFlagUserDefinedRouting = "Microsoft.RedHatOpenShift/UserDefinedRouting"
 )


### PR DESCRIPTION
Removes UserDefinedRouting FeatureFlag.  It doesn't look like its actually used but this change will keep this repo in sync with ARO-RP.