### PR TITLE
Dockerfile.aro: Apply safe.directory configuration to repo

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -7,6 +7,7 @@ WORKDIR ${GOPATH}/src/github.com/openshift/ARO-Installer
 USER root
 RUN yum update -y
 COPY . ${GOPATH}/src/github.com/openshift/ARO-Installer/
+RUN git config --system --add safe.directory '*'
 RUN make aro
 
 FROM ${REGISTRY}/ubi8/ubi-minimal


### PR DESCRIPTION
Fixes the failing **ci/prow/images** check (see below).  This check is currently failing in all other open PRs (https://github.com/openshift/ARO-Installer/pull/22, https://github.com/openshift/ARO-Installer/pull/30).

```
[1/2] STEP 8/8: RUN make aro
go generate ./...
fatal: detected dubious ownership in repository at '/go/src/github.com/openshift/ARO-Installer' 
```

Root cause is a new security feature introduced in Git 2.35.2.  See this blog for context:
https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks

Other repositories under the OpenShift organization are applying similar workarounds.
OpenShift Console, for example: https://github.com/openshift/console/pull/12828#issuecomment-1553244113