### PR TITLE
Correct scope for KV MSI

### DIFF
--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -123,7 +123,7 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		}
 	}
 
-	msiKVAuthorizer, err := p.NewMSIAuthorizer(MSIContextRP, p.Environment().ResourceIdentifiers.KeyVault)
+	msiKVAuthorizer, err := p.NewMSIAuthorizer(MSIContextRP, p.Environment().KeyVaultScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
p.Environment().KeyVaultScope should accommodate both prod (MSI) and dev (certificate) authentication paths