### PR TITLE
Fix the ubi8/go-toolset image tag

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,6 +1,6 @@
 # Uses a multi-stage container build to build ARO-Installer.
 ARG REGISTRY=registry.access.redhat.com
-FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.18.4 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/openshift/ARO-Installer


### PR DESCRIPTION
TIL where to find available tags: [ARO.Build.Images repository in Azure DevOps](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO.Build.Images)