### PR TITLE
Updating go-toolset from 1.19 to 1.19.10

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,6 +1,6 @@
 # Uses a multi-stage container build to build ARO-Installer.
 ARG REGISTRY=registry.access.redhat.com
-FROM ${REGISTRY}/ubi8/go-toolset:1.19 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.19.10 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/openshift/ARO-Installer


### PR DESCRIPTION
[ARO-3198: Release 4.12 image](https://issues.redhat.com/browse/ARO-3198)

This PR is to update the version of go-toolset to the version we mirrored in the Isolated ACR (1.19.10)
https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO.Build.Images/pullrequest/8465849 